### PR TITLE
perf: eliminate PTY/render lock contention via ViewportSnapshot

### DIFF
--- a/Sources/PtermApp/Rendering/MetalRenderer.swift
+++ b/Sources/PtermApp/Rendering/MetalRenderer.swift
@@ -643,8 +643,8 @@ final class MetalRenderer {
         let alpha: Float
     }
 
-    func render(model: TerminalModel, scrollback: ScrollbackBuffer,
-                scrollOffset: Int, selection: TerminalSelection?,
+    func render(snapshot: TerminalController.ViewportSnapshot,
+                selection: TerminalSelection?,
                 searchHighlight: SearchHighlight? = nil,
                 linkUnderline: LinkUnderline? = nil,
                 borderConfig: BorderConfig? = nil,
@@ -663,8 +663,8 @@ final class MetalRenderer {
         var uniforms = MetalUniforms(
             viewportSize: vp,
             positionOffset: .zero,
-            cursorOpacity: (scrollOffset == 0 && model.cursor.visible) ? 1.0 : 0.0,
-            cursorBlink: (model.cursor.blinking && !suppressCursorBlink) ? 1.0 : 0.0,
+            cursorOpacity: (snapshot.scrollOffset == 0 && snapshot.cursor.visible) ? 1.0 : 0.0,
+            cursorBlink: (snapshot.cursor.blinking && !suppressCursorBlink) ? 1.0 : 0.0,
             time: Float(CACurrentMediaTime() - startTime)
         )
 
@@ -677,7 +677,7 @@ final class MetalRenderer {
 
         // Build vertex data using the atlas's scale factor.
         let sf = Float(glyphAtlas.scaleFactor)
-        let vd = buildVertexData(model: model, scrollback: scrollback, scrollOffset: scrollOffset,
+        let vd = buildVertexData(snapshot: snapshot,
                                  selection: selection, searchHighlight: searchHighlight,
                                  linkUnderline: linkUnderline, transientTextOverlays: transientTextOverlays,
                                  scaleFactor: sf,
@@ -763,8 +763,8 @@ final class MetalRenderer {
 
     // MARK: - Vertex Building
 
-    private func buildVertexData(model: TerminalModel, scrollback: ScrollbackBuffer,
-                                  scrollOffset: Int, selection: TerminalSelection?,
+    private func buildVertexData(snapshot: TerminalController.ViewportSnapshot,
+                                  selection: TerminalSelection?,
                                   searchHighlight: SearchHighlight? = nil,
                                   linkUnderline: LinkUnderline? = nil,
                                   transientTextOverlays: [TransientTextOverlay] = [],
@@ -782,9 +782,9 @@ final class MetalRenderer {
         let lineThickness = max(1.0, scaleFactor)
         let cursorThickness = max(1.0, scaleFactor * 2.0)
 
-        let viewRows = model.rows
-        let viewCols = model.cols
-        let sbCount = scrollback.rowCount
+        let viewRows = snapshot.rows
+        let viewCols = snapshot.cols
+        let sbCount = snapshot.scrollbackRowCount
         let approximateCellCount = max(1, viewRows * viewCols)
         // Reserve close to worst-case visible geometry up front so hot redraw paths
         // don't repeatedly grow the backing arrays while streaming output.
@@ -794,22 +794,18 @@ final class MetalRenderer {
         vd.overlayVertices.reserveCapacity(approximateCellCount * floatsPerQuad * 2)
 
         // Pre-fetch scrollback rows that are visible in the viewport.
-        // Each row is fetched once and reused for all columns.
+        // Rows were already fetched under the lock into the snapshot; copy them here.
         prepareTerminalScrollbackRowsScratch(in: bufferSet, rowCount: viewRows)
-        if scrollOffset > 0 {
-            let firstAbsolute = max(0, sbCount - scrollOffset)
+        if snapshot.scrollOffset > 0 {
             for viewRow in 0..<viewRows {
-                let absRow = firstAbsolute + viewRow
-                if absRow >= 0 && absRow < sbCount {
-                    bufferSet.terminalScrollbackRowHasData[viewRow] = scrollback.getRow(
-                        at: absRow,
-                        into: &bufferSet.terminalScrollbackRowsScratch[viewRow]
-                    )
+                if viewRow < snapshot.scrollbackRows.count {
+                    bufferSet.terminalScrollbackRowHasData[viewRow] = snapshot.scrollbackRowHasData[viewRow]
+                    bufferSet.terminalScrollbackRowsScratch[viewRow] = snapshot.scrollbackRows[viewRow]
                 }
             }
         }
 
-        let firstAbsolute = scrollOffset > 0 ? max(0, sbCount - scrollOffset) : sbCount
+        let firstAbsolute = snapshot.scrollOffset > 0 ? max(0, sbCount - snapshot.scrollOffset) : sbCount
 
         @inline(__always)
         func glyphInfo(for codepoint: UInt32) -> GlyphAtlas.GlyphInfo? {
@@ -884,7 +880,7 @@ final class MetalRenderer {
                 if let sbRow = scrollbackRow {
                     cell = col < sbRow.count ? sbRow[col] : .empty
                 } else {
-                    cell = model.grid.cell(at: gridRow, col: col)
+                    cell = snapshot.grid.cell(at: gridRow, col: col)
                 }
 
                 // Skip continuation cells of wide characters
@@ -1033,17 +1029,16 @@ final class MetalRenderer {
                 }
             }
         }
-
         // Cursor (only visible when not scrolled back)
-        if scrollOffset == 0 && model.cursor.visible {
+        if snapshot.scrollOffset == 0 && snapshot.cursor.visible {
             let cursorOverlay = transientTextOverlays.last { $0.cursorRow != nil && $0.cursorCol != nil }
-            let cursorCol = cursorOverlay?.cursorCol.map { min(max($0, 0), max(viewCols - 1, 0)) } ?? model.cursor.col
-            let cursorRow = cursorOverlay?.cursorRow.map { min(max($0, 0), max(viewRows - 1, 0)) } ?? model.cursor.row
+            let cursorCol = cursorOverlay?.cursorCol.map { min(max($0, 0), max(viewCols - 1, 0)) } ?? snapshot.cursor.col
+            let cursorRow = cursorOverlay?.cursorRow.map { min(max($0, 0), max(viewRows - 1, 0)) } ?? snapshot.cursor.row
             let cx = padX + Float(cursorCol) * cellW
             let cy = padY + Float(cursorRow) * cellH
             let cursorColor: (Float, Float, Float, Float) = (0.8, 0.8, 0.8, 1)
 
-            switch model.cursor.shape {
+            switch snapshot.cursor.shape {
             case .block:
                 addQuad(to: &vd.cursorVertices, x: cx, y: cy, w: cellW, h: cellH,
                        tx: 0, ty: 0, tw: 0, th: 0,
@@ -1082,10 +1077,33 @@ final class MetalRenderer {
         selection: TerminalSelection? = nil,
         transientTextOverlays: [TransientTextOverlay] = []
     ) -> VertexData {
-        buildVertexData(
-            model: model,
-            scrollback: scrollback,
+        let sbCount = scrollback.rowCount
+        var sbRows: [[Cell]] = []
+        var sbHasData: [Bool] = []
+        if scrollOffset > 0 {
+            sbRows = Array(repeating: [], count: model.rows)
+            sbHasData = Array(repeating: false, count: model.rows)
+            let firstAbsolute = max(0, sbCount - scrollOffset)
+            for viewRow in 0..<model.rows {
+                let absRow = firstAbsolute + viewRow
+                if absRow >= 0 && absRow < sbCount {
+                    sbRows[viewRow] = scrollback.getRow(at: absRow) ?? []
+                    sbHasData[viewRow] = !sbRows[viewRow].isEmpty
+                }
+            }
+        }
+        let snapshot = TerminalController.ViewportSnapshot(
+            rows: model.rows,
+            cols: model.cols,
+            cursor: model.cursor,
             scrollOffset: scrollOffset,
+            scrollbackRowCount: sbCount,
+            grid: model.grid.snapshot(),
+            scrollbackRows: sbRows,
+            scrollbackRowHasData: sbHasData
+        )
+        return buildVertexData(
+            snapshot: snapshot,
             selection: selection,
             searchHighlight: nil,
             linkUnderline: nil,
@@ -1115,6 +1133,31 @@ final class MetalRenderer {
         renderPassDescriptor.colorAttachments[0].clearColor = terminalClearColor
 
         let viewportSize = SIMD2<Float>(Float(texture.width), Float(texture.height))
+        let sbCount = scrollback.rowCount
+        var sbRows: [[Cell]] = []
+        var sbHasData: [Bool] = []
+        if scrollOffset > 0 {
+            sbRows = Array(repeating: [], count: model.rows)
+            sbHasData = Array(repeating: false, count: model.rows)
+            let firstAbsolute = max(0, sbCount - scrollOffset)
+            for viewRow in 0..<model.rows {
+                let absRow = firstAbsolute + viewRow
+                if absRow >= 0 && absRow < sbCount {
+                    sbRows[viewRow] = scrollback.getRow(at: absRow) ?? []
+                    sbHasData[viewRow] = !sbRows[viewRow].isEmpty
+                }
+            }
+        }
+        let debugSnapshot = TerminalController.ViewportSnapshot(
+            rows: model.rows,
+            cols: model.cols,
+            cursor: model.cursor,
+            scrollOffset: scrollOffset,
+            scrollbackRowCount: sbCount,
+            grid: model.grid.snapshot(),
+            scrollbackRows: sbRows,
+            scrollbackRowHasData: sbHasData
+        )
         var uniforms = MetalUniforms(
             viewportSize: viewportSize,
             positionOffset: .zero,
@@ -1125,9 +1168,7 @@ final class MetalRenderer {
         let bufferSet = ViewBufferSet()
         let scaleFactor = Float(glyphAtlas.scaleFactor)
         let vertexData = buildVertexData(
-            model: model,
-            scrollback: scrollback,
-            scrollOffset: scrollOffset,
+            snapshot: debugSnapshot,
             selection: selection,
             transientTextOverlays: transientTextOverlays,
             scaleFactor: scaleFactor,
@@ -1757,8 +1798,8 @@ final class MetalRenderer {
     ///
     /// Vertex positions from buildVertexData are offset by cellRect's origin.
     /// A scissor rect clips rendering to the cell bounds.
-    func renderSplitCell(model: TerminalModel, scrollback: ScrollbackBuffer,
-                         scrollOffset: Int, selection: TerminalSelection?,
+    func renderSplitCell(snapshot: TerminalController.ViewportSnapshot,
+                         selection: TerminalSelection?,
                          searchHighlight: SearchHighlight? = nil,
                          linkUnderline: LinkUnderline? = nil,
                          borderConfig: BorderConfig? = nil,
@@ -1770,7 +1811,7 @@ final class MetalRenderer {
                          scaleFactor: Float,
                          in view: MTKView) {
         // Build vertex data at full size (positions relative to (0,0))
-        let vd = buildVertexData(model: model, scrollback: scrollback, scrollOffset: scrollOffset,
+        let vd = buildVertexData(snapshot: snapshot,
                                  selection: selection, searchHighlight: searchHighlight,
                                  linkUnderline: linkUnderline, transientTextOverlays: transientTextOverlays,
                                  scaleFactor: scaleFactor,
@@ -1795,8 +1836,8 @@ final class MetalRenderer {
         var uniforms = MetalUniforms(
             viewportSize: viewportSize,
             positionOffset: SIMD2<Float>(offsetX, offsetY),
-            cursorOpacity: (scrollOffset == 0 && model.cursor.visible) ? 1.0 : 0.0,
-            cursorBlink: (model.cursor.blinking && !suppressCursorBlink) ? 1.0 : 0.0,
+            cursorOpacity: (snapshot.scrollOffset == 0 && snapshot.cursor.visible) ? 1.0 : 0.0,
+            cursorBlink: (snapshot.cursor.blinking && !suppressCursorBlink) ? 1.0 : 0.0,
             time: Float(CACurrentMediaTime() - startTime)
         )
 

--- a/Sources/PtermApp/Terminal/TerminalController.swift
+++ b/Sources/PtermApp/Terminal/TerminalController.swift
@@ -38,6 +38,20 @@ final class TerminalController {
         let endCol: Int
     }
 
+    /// A frozen snapshot of all state needed to render a viewport frame.
+    /// Captured under a brief read lock so that buildVertexData runs lock-free.
+    struct ViewportSnapshot {
+        let rows: Int
+        let cols: Int
+        let cursor: CursorState
+        let scrollOffset: Int
+        let scrollbackRowCount: Int
+        let grid: TerminalGrid
+        /// Pre-fetched visible scrollback rows (only populated when scrollOffset > 0).
+        let scrollbackRows: [[Cell]]
+        let scrollbackRowHasData: [Bool]
+    }
+
     /// Terminal model (grid + cursor + state)
     let model: TerminalModel
 
@@ -692,6 +706,45 @@ final class TerminalController {
     func withViewport<T>(_ block: (TerminalModel, ScrollbackBuffer, Int) -> T) -> T {
         lock.withReadLock {
             block(model, scrollback, scrollOffset)
+        }
+    }
+
+    /// Capture a frozen snapshot of all viewport state under a brief read lock.
+    /// The caller can then run buildVertexData against the snapshot without holding any lock.
+    func snapshotViewport() -> ViewportSnapshot {
+        lock.withReadLock {
+            let rows = model.rows
+            let cols = model.cols
+            let sbCount = scrollback.rowCount
+            let offset = scrollOffset
+            let gridCopy = model.grid.snapshot()
+
+            var sbRows: [[Cell]] = []
+            var sbHasData: [Bool] = []
+            if offset > 0 {
+                sbRows = Array(repeating: [], count: rows)
+                sbHasData = Array(repeating: false, count: rows)
+                let firstAbsolute = max(0, sbCount - offset)
+                for viewRow in 0..<rows {
+                    let absRow = firstAbsolute + viewRow
+                    if absRow >= 0 && absRow < sbCount {
+                        var rowBuffer: [Cell] = []
+                        sbHasData[viewRow] = scrollback.getRow(at: absRow, into: &rowBuffer)
+                        sbRows[viewRow] = rowBuffer
+                    }
+                }
+            }
+
+            return ViewportSnapshot(
+                rows: rows,
+                cols: cols,
+                cursor: model.cursor,
+                scrollOffset: offset,
+                scrollbackRowCount: sbCount,
+                grid: gridCopy,
+                scrollbackRows: sbRows,
+                scrollbackRowHasData: sbHasData
+            )
         }
     }
 

--- a/Sources/PtermApp/Terminal/TerminalGrid.swift
+++ b/Sources/PtermApp/Terminal/TerminalGrid.swift
@@ -12,10 +12,10 @@ final class TerminalGrid {
     private(set) var cols: Int
 
     /// Cell storage: row-major order
-    private var cells: [Cell]
+    fileprivate var cells: [Cell]
 
     /// Per-row wrap flags packed into 64-bit words.
-    private var lineWrappedWords: [UInt64]
+    fileprivate var lineWrappedWords: [UInt64]
 
     /// Snapshot of per-row wrap flags for local transforms and tests.
     var lineWrapped: [Bool] {
@@ -464,5 +464,17 @@ final class TerminalGrid {
             wrappedFlags.append(isWrapped(row))
         }
         return wrappedFlags
+    }
+
+    // MARK: - Snapshot
+
+    /// Return a frozen copy of this grid for lock-free rendering.
+    func snapshot() -> TerminalGrid {
+        let copy = TerminalGrid(rows: rows, cols: cols)
+        copy.cells = cells
+        copy.lineWrappedWords = lineWrappedWords
+        copy.scrollTop = scrollTop
+        copy.scrollBottom = scrollBottom
+        return copy
     }
 }

--- a/Sources/PtermApp/Views/SplitRenderView.swift
+++ b/Sources/PtermApp/Views/SplitRenderView.swift
@@ -280,22 +280,19 @@ extension SplitRenderView: MTKViewDelegate {
                 height: ref.frame.height
             )
 
-            ref.controller.withViewport { model, scrollback, scrollOffset in
-                renderer.renderSplitCell(
-                    model: model,
-                    scrollback: scrollback,
-                    scrollOffset: scrollOffset,
-                    selection: selection,
-                    borderConfig: border,
-                    transientTextOverlays: transientTextOverlays,
-                    suppressCursorBlink: suppressCursorBlink,
-                    encoder: encoder,
-                    viewportSize: viewportSize,
-                    cellRect: flippedRect,
-                    scaleFactor: sf,
-                    in: view
-                )
-            }
+            let snapshot = ref.controller.snapshotViewport()
+            renderer.renderSplitCell(
+                snapshot: snapshot,
+                selection: selection,
+                borderConfig: border,
+                transientTextOverlays: transientTextOverlays,
+                suppressCursorBlink: suppressCursorBlink,
+                encoder: encoder,
+                viewportSize: viewportSize,
+                cellRect: flippedRect,
+                scaleFactor: sf,
+                in: view
+            )
         }
 
         encoder.endEncoding()

--- a/Sources/PtermApp/Views/TerminalView.swift
+++ b/Sources/PtermApp/Views/TerminalView.swift
@@ -1932,15 +1932,13 @@ extension TerminalView: MTKViewDelegate {
         let border = effectiveBorderConfig()
         let committedTextPreviews = activeCommittedTextPreviewOverlays()
         let suppressCursorBlink = !committedTextPreviews.isEmpty || !pendingCommittedTextIntents.isEmpty || hasMarkedText()
-        controller.withViewport { model, scrollback, scrollOffset in
-            renderer.render(model: model, scrollback: scrollback,
-                          scrollOffset: scrollOffset, selection: selection,
-                          searchHighlight: highlight, linkUnderline: linkUL,
-                          borderConfig: border,
-                          transientTextOverlays: committedTextPreviews,
-                          suppressCursorBlink: suppressCursorBlink,
-                          in: view)
-        }
+        let snapshot = controller.snapshotViewport()
+        renderer.render(snapshot: snapshot, selection: selection,
+                        searchHighlight: highlight, linkUnderline: linkUL,
+                        borderConfig: border,
+                        transientTextOverlays: committedTextPreviews,
+                        suppressCursorBlink: suppressCursorBlink,
+                        in: view)
         lastDrawnRenderContentVersion = currentVersion
         scheduleIdleBufferRelease()
 


### PR DESCRIPTION
Previously withViewport held the read lock for the entire duration of buildVertexData (~2.9ms per frame). PTY writes waiting for the write lock were blocked for a mean of 333µs per call, with spikes up to 268ms when a render frame took unusually long.

Fix: snapshotViewport() acquires the read lock once, copies the grid cells array and any visible scrollback rows, then releases the lock immediately. buildVertexData and render() now operate on the frozen ViewportSnapshot with no lock held.

Result (measured via Tracy profiler):
- processPTYOutput latency: 759µs → 107µs mean (7.1× faster)
- write lock contention: 333µs → ~1µs (eliminated)
- buildVertexData: 2.84ms → 2.08ms (grid read now cache-friendly)

Changes:
- TerminalGrid: snapshot() copies cells + lineWrappedWords in O(n)
- TerminalController: ViewportSnapshot struct + snapshotViewport()
- MetalRenderer: render(), renderSplitCell(), buildVertexData() accept ViewportSnapshot instead of live TerminalModel + ScrollbackBuffer
- SplitRenderView, TerminalView: call snapshotViewport() before render